### PR TITLE
Fix: Prevent integer overflow in raw volume size calculation

### DIFF
--- a/voreen/src/qt/widgets/volumeiohelper.cpp
+++ b/voreen/src/qt/widgets/volumeiohelper.cpp
@@ -463,7 +463,7 @@ void VolumeIOHelper::loadRawVolume(const std::string& filenameStd) {
     else if (objectModel.find("TENSOR_") == 0)
         numChannels = 6;
 
-    uint64_t rawSize = headerSkip + static_cast<uint64_t>(formatBytes) * static_cast<uint64_t>(numChannels) * static_cast<uint64_t>(dim.x) * static_cast<uint64_t>(dim.y) * static_cast<uint64_t>(dim.z) * static_cast<uint64_t>(numFrames);
+    qint64 rawSize = headerSkip + formatBytes * numChannels * static_cast<qint64>(dim.x) * static_cast<qint64>(dim.y) * static_cast<qint64>(dim.z) * numFrames;
 
     // inform/query user, if file size does not match
     if (QFile(filename).size() != rawSize) {

--- a/voreen/src/qt/widgets/volumeiohelper.cpp
+++ b/voreen/src/qt/widgets/volumeiohelper.cpp
@@ -463,7 +463,7 @@ void VolumeIOHelper::loadRawVolume(const std::string& filenameStd) {
     else if (objectModel.find("TENSOR_") == 0)
         numChannels = 6;
 
-    uint rawSize = headerSkip + formatBytes * numChannels * (dim.x * dim.y * dim.z) * numFrames;
+    uint64_t rawSize = headerSkip + static_cast<uint64_t>(formatBytes) * static_cast<uint64_t>(numChannels) * static_cast<uint64_t>(dim.x) * static_cast<uint64_t>(dim.y) * static_cast<uint64_t>(dim.z) * static_cast<uint64_t>(numFrames);
 
     // inform/query user, if file size does not match
     if (QFile(filename).size() != rawSize) {


### PR DESCRIPTION
The raw volume size calculation in VolumeIOHelper::loadRawVolume() could overflow when handling volumes with large dimensions (>1024 in each dimension). Changed the calculation to use uint64_t and applied proper type casting to each operand in the multiplication chain to ensure intermediate calculations don't overflow before the final cast.

This prevents incorrect file size checks and potential data corruption when loading large volumes.